### PR TITLE
feat: thêm nút hủy cuộc trò chuyện màu đỏ nhạt khi đang lắng nghe (cl…

### DIFF
--- a/app/src/main/java/com/example/ViDroidCall_Studio/feature/assistant/AssistantScreen.kt
+++ b/app/src/main/java/com/example/ViDroidCall_Studio/feature/assistant/AssistantScreen.kt
@@ -93,6 +93,7 @@ fun AssistantScreen(
     isListening: Boolean,
     speechText: String,
     onToggleListening: () -> Unit,
+    onCancelListening: () -> Unit = {},
     nluResult: NluResult?,
     isNluProcessing: Boolean,
     modelState: NluModelState,
@@ -127,7 +128,8 @@ fun AssistantScreen(
             isNluProcessing = isNluProcessing,
             modelState = modelState,
             isTtsSpeaking = isTtsSpeaking,
-            onToggleListening = onToggleListening
+            onToggleListening = onToggleListening,
+            onCancelListening = onCancelListening
         )
 
         Spacer(modifier = Modifier.height(20.dp))
@@ -210,7 +212,8 @@ private fun VoiceAssistantSection(
     isNluProcessing: Boolean,
     modelState: NluModelState,
     isTtsSpeaking: Boolean = false,
-    onToggleListening: () -> Unit
+    onToggleListening: () -> Unit,
+    onCancelListening: () -> Unit = {}
 ) {
     val context = LocalContext.current
     val isAiReady = modelState is NluModelState.Ready
@@ -446,30 +449,78 @@ private fun VoiceAssistantSection(
             enter = fadeIn() + expandVertically(),
             exit = fadeOut() + shrinkVertically()
         ) {
-            val buttonBgColor = when {
-                !isAiReady -> MaterialTheme.colorScheme.primary.copy(alpha = 0.06f)
-                isListening -> MaterialTheme.colorScheme.primary.copy(alpha = 0.20f)
-                else -> MaterialTheme.colorScheme.primary.copy(alpha = 0.12f)
-            }
-            val buttonTextColor = when {
-                !isAiReady -> MaterialTheme.colorScheme.primary.copy(alpha = 0.40f)
-                else -> MaterialTheme.colorScheme.primary
-            }
+            if (isListening) {
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    // Nút Dừng nghe (Màu xanh)
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .background(
+                                color = MaterialTheme.colorScheme.primary.copy(alpha = 0.20f),
+                                shape = RoundedCornerShape(22.dp)
+                            )
+                            .bounceClick(scaleDown = 0.95f, onClick = handleActionClick)
+                            .padding(vertical = 18.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = "Dừng nghe",
+                            fontSize = 19.sp,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.primary
+                        )
+                    }
 
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .background(buttonBgColor, RoundedCornerShape(22.dp))
-                    .bounceClick(scaleDown = if (isAiReady) 0.95f else 0.98f, onClick = handleActionClick)
-                    .padding(vertical = 18.dp),
-                contentAlignment = Alignment.Center
-            ) {
-                Text(
-                    text = if (isListening) "Dừng nghe" else "Nhấn để bắt đầu nói",
-                    fontSize = 19.sp,
-                    fontWeight = FontWeight.Bold,
-                    color = buttonTextColor
-                )
+                    // Nút Hủy cuộc trò chuyện (Màu đỏ nhạt)
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .background(
+                                color = Color(0xFFEF4444).copy(alpha = 0.14f),
+                                shape = RoundedCornerShape(22.dp)
+                            )
+                            .bounceClick(scaleDown = 0.95f, onClick = onCancelListening)
+                            .padding(vertical = 18.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = "Hủy cuộc trò chuyện",
+                            fontSize = 19.sp,
+                            fontWeight = FontWeight.Bold,
+                            color = Color(0xFFDC2626)
+                        )
+                    }
+                }
+            } else {
+                val buttonBgColor = if (!isAiReady) {
+                    MaterialTheme.colorScheme.primary.copy(alpha = 0.06f)
+                } else {
+                    MaterialTheme.colorScheme.primary.copy(alpha = 0.12f)
+                }
+                val buttonTextColor = if (!isAiReady) {
+                    MaterialTheme.colorScheme.primary.copy(alpha = 0.40f)
+                } else {
+                    MaterialTheme.colorScheme.primary
+                }
+
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(buttonBgColor, RoundedCornerShape(22.dp))
+                        .bounceClick(scaleDown = if (isAiReady) 0.95f else 0.98f, onClick = handleActionClick)
+                        .padding(vertical = 18.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = "Nhấn để bắt đầu nói",
+                        fontSize = 19.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = buttonTextColor
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/example/ViDroidCall_Studio/feature/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/ViDroidCall_Studio/feature/home/HomeScreen.kt
@@ -135,6 +135,10 @@ fun HomeScreen(
         }
     }
 
+    val handleCancelListening: () -> Unit = {
+        speechToText.cancelListening()
+    }
+
     Scaffold(
         modifier = modifier
             .fillMaxSize()
@@ -160,6 +164,7 @@ fun HomeScreen(
                     isListening = speechToText.isListening,
                     speechText = speechToText.speechText,
                     onToggleListening = handleToggleListeningSafe,
+                    onCancelListening = handleCancelListening,
                     nluResult = nluResult,
                     isNluProcessing = isNluProcessing,
                     modelState = modelState,

--- a/app/src/main/java/com/example/ViDroidCall_Studio/feature/speech/RememberSpeechToText.kt
+++ b/app/src/main/java/com/example/ViDroidCall_Studio/feature/speech/RememberSpeechToText.kt
@@ -17,7 +17,8 @@ data class SpeechToTextState(
     val isListening: Boolean,
     val speechText: String,
     val toggleListening: () -> Unit,
-    val stopListening: () -> Unit
+    val stopListening: () -> Unit,
+    val cancelListening: () -> Unit
 )
 
 /**
@@ -99,10 +100,17 @@ fun rememberSpeechToText(
         isListeningState = false
     }
 
+    val cancelListening: () -> Unit = {
+        manager.cancelListening()
+        speechTextState = ""
+        isListeningState = false
+    }
+
     return SpeechToTextState(
         isListening = isListeningState,
         speechText = speechTextState,
         toggleListening = toggleListening,
-        stopListening = stopListening
+        stopListening = stopListening,
+        cancelListening = cancelListening
     )
 }

--- a/app/src/main/java/com/example/ViDroidCall_Studio/feature/speech/SpeechToTextManager.kt
+++ b/app/src/main/java/com/example/ViDroidCall_Studio/feature/speech/SpeechToTextManager.kt
@@ -26,9 +26,11 @@ class SpeechToTextManager(
     private val mainHandler = Handler(Looper.getMainLooper())
     private var speechRecognizer: SpeechRecognizer? = null
     private var isListeningActive = false
+    private var isCancelled = false
 
     private val recognitionListener = object : RecognitionListener {
         override fun onReadyForSpeech(params: Bundle?) {
+            if (isCancelled) return
             isListeningActive = true
             mainHandler.post {
                 callbacks.onListeningChanged(true)
@@ -38,6 +40,7 @@ class SpeechToTextManager(
         }
 
         override fun onBeginningOfSpeech() {
+            if (isCancelled) return
             Log.d(TAG, "SpeechRecognizer: Người dùng bắt đầu nói...")
         }
 
@@ -46,6 +49,7 @@ class SpeechToTextManager(
         override fun onBufferReceived(buffer: ByteArray?) = Unit
 
         override fun onEndOfSpeech() {
+            if (isCancelled) return
             isListeningActive = false
             mainHandler.post {
                 callbacks.onListeningChanged(false)
@@ -54,6 +58,10 @@ class SpeechToTextManager(
         }
 
         override fun onError(error: Int) {
+            if (isCancelled) {
+                Log.d(TAG, "SpeechRecognizer onError ($error) bỏ qua vì người dùng đã hủy.")
+                return
+            }
             isListeningActive = false
             val errorMessage = when (error) {
                 SpeechRecognizer.ERROR_AUDIO -> "Lỗi thu âm. Vui lòng thử lại."
@@ -74,6 +82,10 @@ class SpeechToTextManager(
         }
 
         override fun onResults(results: Bundle?) {
+            if (isCancelled) {
+                Log.d(TAG, "SpeechRecognizer onResults bỏ qua vì người dùng đã hủy.")
+                return
+            }
             isListeningActive = false
             val matches = results?.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION) ?: emptyList<String>()
 
@@ -99,6 +111,7 @@ class SpeechToTextManager(
         }
 
         override fun onPartialResults(partialResults: Bundle?) {
+            if (isCancelled) return
             val matches = partialResults?.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION)
             val partial = matches?.firstOrNull { it.isNotBlank() }
             if (!partial.isNullOrBlank()) {
@@ -140,6 +153,7 @@ class SpeechToTextManager(
 
                 if (!ensureRecognizer()) return@post
 
+                isCancelled = false
                 val intent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
                     putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_FREE_FORM)
                     putExtra(RecognizerIntent.EXTRA_LANGUAGE, LANGUAGE_VI_VN)
@@ -177,9 +191,25 @@ class SpeechToTextManager(
         }
     }
 
+    fun cancelListening() {
+        mainHandler.post {
+            try {
+                isCancelled = true
+                isListeningActive = false
+                speechRecognizer?.cancel()
+            } catch (e: Exception) {
+                Log.w(TAG, "Lỗi khi gọi cancelListening: ${e.message}")
+            } finally {
+                callbacks.onListeningChanged(false)
+                callbacks.onTextChanged("")
+            }
+        }
+    }
+
     fun destroy() {
         mainHandler.post {
             try {
+                isCancelled = true
                 speechRecognizer?.cancel()
                 speechRecognizer?.destroy()
             } catch (e: Exception) {


### PR DESCRIPTION
### 🎯 Mục tiêu & Tổng quan
Bổ sung nút **"Hủy cuộc trò chuyện"** (màu đỏ nhạt pastel) hiển thị khi Trợ lý AI đang trong trạng thái lắng nghe giọng nói (`isListening == true`), cho phép người dùng dừng thu âm ngay lập tức, tránh kích hoạt phân tích AI khi nói nhầm hoặc đổi ý.

### 🛠️ Chi tiết thay đổi
- **SpeechToTextManager & `rememberSpeechToText`**:
  - Bổ sung phương thức `cancelListening()`: dừng bộ thu âm `SpeechRecognizer.cancel()`, reset trạng thái lắng nghe.
  - Thêm cờ `isCancelled` để chặn các callback `onError`, `onResults` khi đã hủy, tránh gửi chuỗi sang mô hình AI.
  - Tự động xóa sạch chuỗi nhận diện tạm thời (`speechText = ""`).
- **Giao diện `AssistantScreen.kt`**:
  - Thêm nút "Hủy cuộc trò chuyện" màu đỏ nhạt (`Color(0xFFEF4444).copy(alpha = 0.14f)`), chữ đỏ đậm `Color(0xFFDC2626)`.
  - Chuẩn UI/UX: bo góc `22.dp`, hiệu ứng `bounceClick`, padding lớn dễ thao tác cho người cao tuổi.
- **Điều phối `HomeScreen.kt`**:
  - Kết nối callback `cancelListening` từ SpeechToText đến `AssistantScreen`.

### ✅ Kiểm thử
- [x] Đã chạy toàn bộ unit tests: `./gradlew testDebugUnitTest` (Passed 100%).
- [x] Giao diện trở về trạng thái chờ sẵn sàng ban đầu ngay khi nhấn Hủy.

Closes #24
