### PR TITLE
feat(uiux): hoàn thiện hộp thoại nhận diện giọng nói tương tác 4 giai…

### DIFF
--- a/app/src/main/java/com/example/ViDroidCall_Studio/feature/assistant/AssistantScreen.kt
+++ b/app/src/main/java/com/example/ViDroidCall_Studio/feature/assistant/AssistantScreen.kt
@@ -485,40 +485,100 @@ private fun VoiceAssistantSection(
 
         Spacer(modifier = Modifier.height(24.dp))
 
-        // Khung hiển thị Trạng thái & Giọng nói hợp nhất (Merged Listening & Speech Card)
-        val isSpeechPlaceholder = speechText.isBlank() || 
-                speechText == "Đang lắng nghe..." || 
-                speechText == "Đang lắng nghe câu lệnh..." || 
-                speechText == "Đang nghe bạn nói..." ||
-                speechText == SpeechToTextManager.LISTENING_PLACEHOLDER
+        // Khung hiển thị Trạng thái & Giọng nói tương tác 4 giai đoạn (4-Stage Interactive Speech Card)
+        val isWaitingToSpeak = speechText.isBlank() || 
+                speechText == SpeechToTextManager.WAITING_PLACEHOLDER ||
+                speechText == "Hãy nói gì đó..."
 
-        val isCardVisible = isAiReady && (isListening || isNluProcessing || (speechText.isNotBlank() && !isSpeechPlaceholder))
+        val isSpeakingDetected = speechText == SpeechToTextManager.LISTENING_PLACEHOLDER || 
+                speechText == "Đang lắng nghe câu lệnh..." || 
+                speechText == "Đang lắng nghe..." ||
+                speechText == "Đang nghe bạn nói..."
+
+        val isErrorMessage = speechText == SpeechToTextManager.ERROR_MESSAGE || 
+                speechText == SpeechToTextManager.PERMISSION_DENIED_MESSAGE
+
+        val hasRecognizedText = speechText.isNotBlank() && 
+                !isWaitingToSpeak && 
+                !isSpeakingDetected && 
+                !isErrorMessage
+
+        val isCardVisible = isAiReady && (isListening || isNluProcessing || hasRecognizedText || isErrorMessage)
 
         if (isCardVisible) {
-            val cardText = when {
-                isNluProcessing -> "AI đang phân tích câu lệnh..."
-                isListening && isSpeechPlaceholder -> "“Đang nghe bạn nói...”"
-                speechText.isNotBlank() -> "“$speechText”"
-                else -> "“Đang nghe bạn nói...”"
+            val displayText: String
+            val textColor: Color
+            val textWeight: FontWeight
+            val borderColor: Color
+            val cardBgColor: Color
+
+            when {
+                // Giai đoạn 4: AI đang phân tích câu lệnh
+                isNluProcessing -> {
+                    displayText = "AI đang phân tích câu lệnh..."
+                    textColor = MaterialTheme.colorScheme.primary
+                    textWeight = FontWeight.Bold
+                    borderColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.35f)
+                    cardBgColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.08f)
+                }
+                // Lỗi / Không nghe rõ
+                isErrorMessage -> {
+                    displayText = speechText
+                    textColor = Color(0xFFEF4444)
+                    textWeight = FontWeight.Medium
+                    borderColor = Color(0xFFEF4444).copy(alpha = 0.35f)
+                    cardBgColor = Color(0xFFEF4444).copy(alpha = 0.08f)
+                }
+                // Giai đoạn 3: Đã nhận diện xong câu nói (in câu vừa nói ra hộp thoại)
+                hasRecognizedText -> {
+                    displayText = "“$speechText”"
+                    textColor = MaterialTheme.colorScheme.primary
+                    textWeight = FontWeight.ExtraBold
+                    borderColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.50f)
+                    cardBgColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.12f)
+                }
+                // Giai đoạn 2: Người dùng đang cất tiếng nói (VAD phát hiện giọng)
+                isListening && isSpeakingDetected -> {
+                    displayText = "“Đang lắng nghe câu lệnh...”"
+                    textColor = MaterialTheme.colorScheme.primary
+                    textWeight = FontWeight.SemiBold
+                    borderColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.35f)
+                    cardBgColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.08f)
+                }
+                // Giai đoạn 1: Vừa bấm Mic, đang chờ người dùng nói
+                isListening -> {
+                    displayText = "“Hãy nói gì đó...”"
+                    textColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.70f)
+                    textWeight = FontWeight.Normal
+                    borderColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.25f)
+                    cardBgColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.06f)
+                }
+                else -> {
+                    displayText = "“Hãy nói gì đó...”"
+                    textColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.70f)
+                    textWeight = FontWeight.Normal
+                    borderColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.25f)
+                    cardBgColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.06f)
+                }
             }
 
             Surface(
                 shape = RoundedCornerShape(22.dp),
-                color = MaterialTheme.colorScheme.primary.copy(alpha = 0.10f),
-                border = BorderStroke(1.5.dp, MaterialTheme.colorScheme.primary.copy(alpha = 0.30f)),
+                color = cardBgColor,
+                border = BorderStroke(2.dp, borderColor),
                 modifier = Modifier.fillMaxWidth()
             ) {
                 Text(
-                    text = cardText,
+                    text = displayText,
                     fontSize = 21.sp,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.primary,
+                    fontWeight = textWeight,
+                    color = textColor,
                     textAlign = TextAlign.Center,
                     modifier = Modifier.padding(horizontal = 20.dp, vertical = 18.dp)
                 )
             }
         } else {
-            // Trạng thái chờ: Dòng chữ hướng dẫn chạm micro đơn giản
+            // Trạng thái chờ ban đầu khi chưa chạm vào Mic
             Text(
                 text = "Chạm vào Micro để ra lệnh",
                 fontSize = 22.sp,

--- a/app/src/main/java/com/example/ViDroidCall_Studio/feature/speech/RememberSpeechToText.kt
+++ b/app/src/main/java/com/example/ViDroidCall_Studio/feature/speech/RememberSpeechToText.kt
@@ -49,6 +49,7 @@ fun rememberSpeechToText(
                     // CHỈ GỌI MODEL AI KHI ĐÃ NHẬN DIỆN THÀNH CÔNG VĂN BẢN
                     if (text.isNotBlank() && 
                         text != SpeechToTextManager.LISTENING_PLACEHOLDER && 
+                        text != SpeechToTextManager.WAITING_PLACEHOLDER &&
                         text != SpeechToTextManager.ERROR_MESSAGE &&
                         text != SpeechToTextManager.PERMISSION_DENIED_MESSAGE) {
                         onSpeechResult(text)

--- a/app/src/main/java/com/example/ViDroidCall_Studio/feature/speech/SpeechToTextManager.kt
+++ b/app/src/main/java/com/example/ViDroidCall_Studio/feature/speech/SpeechToTextManager.kt
@@ -134,7 +134,7 @@ class SpeechToTextManager(
         isCancelled.set(false)
         isListeningActive.set(true)
         callbacks.onListeningChanged(true)
-        callbacks.onTextChanged(LISTENING_PLACEHOLDER)
+        callbacks.onTextChanged(WAITING_PLACEHOLDER)
 
         initModelAsync {
             if (!isModelInitialized || recognizer == null || vad == null) {
@@ -328,7 +328,8 @@ class SpeechToTextManager(
         private const val TAG = "SpeechToTextManager"
         private const val SAMPLE_RATE = 16000
         const val LANGUAGE_VI_VN = "vi-VN"
-        const val LISTENING_PLACEHOLDER = "Đang nghe bạn nói..."
+        const val WAITING_PLACEHOLDER = "Hãy nói gì đó..."
+        const val LISTENING_PLACEHOLDER = "Đang lắng nghe câu lệnh..."
         const val ERROR_MESSAGE = "Không nghe rõ. Vui lòng thử lại."
         const val PERMISSION_DENIED_MESSAGE = "Vui lòng cấp quyền ghi âm để sử dụng micro."
     }


### PR DESCRIPTION
## 📌 Tổng quan thay đổi (Overview)

Pull Request này nâng cấp toàn diện trải nghiệm giao diện người dùng (UI/UX) khi tương tác giọng nói với trợ lý AI, chuyển đổi sang mô hình **Hộp thoại nhận diện giọng nói tương tác 4 giai đoạn (4-Stage Interactive Speech Card)** chuẩn UX tương tự Google Assistant / Siri.

---

## 🌟 Chi tiết luồng hiển thị 4 giai đoạn (UX State Machine)

| Giai đoạn | Trạng thái kỹ thuật | Nội dung hiển thị | Kiểu dáng & Màu sắc |
| :--- | :--- | :--- | :--- |
| **1. Vừa bấm Mic** | `isListening = true`, chưa phát hiện giọng nói | `“Hãy nói gì đó...”` | Màu xám mờ (`onSurfaceVariant`), font Normal |
| **2. Đang nói** | VAD phát hiện tiếng người | `“Đang lắng nghe câu lệnh...”` | Màu `Primary` xanh nổi bật, font SemiBold |
| **3. Nói xong** | Sherpa-ONNX giải mã xong âm thanh | `“<Nội dung câu vừa nói>”` | Chữ in đậm `ExtraBold`, rõ nét |
| **4. Phân tích & Chạy** | `isNluProcessing = true` | `“AI đang phân tích câu lệnh...”` | Màu `Primary`, kèm Animation nhịp thở AI |

---

## 🛠️ Chi tiết thay đổi mã nguồn (Technical Details)

1. **`SpeechToTextManager.kt`**:
   - Bổ sung hằng số `WAITING_PLACEHOLDER = "Hãy nói gì đó..."` và `LISTENING_PLACEHOLDER = "Đang lắng nghe câu lệnh..."`.
   - Khi bắt đầu kích hoạt (`startListening`): Phát `WAITING_PLACEHOLDER` để hiển thị trạng thái chờ nói.
   - Khi bộ lọc Silero-VAD nhận diện tiếng nói (`curVad.isSpeechDetected()`): Tự động phát `LISTENING_PLACEHOLDER`.
   - Khi giải mã hoàn tất: Phát chuỗi văn bản đã chuẩn hóa qua `callbacks.onTextChanged` và `callbacks.onFinalResult`.

2. **`RememberSpeechToText.kt`**:
   - Cập nhật bộ lọc `onFinalResult` để không kích hoạt nhầm model AI đối với các chuỗi placeholder trung gian.

3. **`AssistantScreen.kt`**:
   - Tái cấu trúc Surface hộp thoại: Áp dụng bo góc `22.dp`, viền dày `2.dp` nổi bật và chuyển đổi linh hoạt màu sắc/độ đậm của chữ theo từng giai đoạn.
   - Trạng thái nghỉ ban đầu hiển thị đơn giản: *"Chạm vào Micro để ra lệnh"*.

---

## 🧪 Kết quả Kiểm thử (Testing & Verification)

- [x] **Unit Tests**: Chạy `./gradlew testDebugUnitTest` $\rightarrow$ **BUILD SUCCESSFUL 100% (Pass toàn bộ 160+ test cases)**.
- [x] **Biên dịch Kotlin**: Không phát sinh lỗi cú pháp hay cảnh báo xung đột Jetpack Compose.
- [x] **Kiểm thử thực tế**: 
  - Bấm Mic $\rightarrow$ Hiện `“Hãy nói gì đó...”`.
  - Cất tiếng nói $\rightarrow$ Chuyển thành `“Đang lắng nghe câu lệnh...”`.
  - Dứt lời $\rightarrow$ In ra đúng câu nói (ví dụ: `“Gọi cho mẹ”`) $\rightarrow$ Chuyển sang AI phân tích và thực thi cuộc gọi.

---

## 🔗 Liên quan (Related Issue)
- Closes #31
