### PR TITLE
Feature/51 tro ly noi foreground service

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,8 @@
     <uses-permission android:name="com.android.alarm.permission.SET_ALARM" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <uses-permission android:name="android.permission.READ_CONTACTS" />
     <uses-permission android:name="android.permission.CALL_PHONE" />
@@ -56,6 +58,11 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/file_paths" />
         </provider>
+
+        <service
+            android:name=".feature.overlay.TroLyNoiForegroundService"
+            android:exported="false"
+            android:foregroundServiceType="microphone" />
 
         <activity
             android:name=".MainActivity"

--- a/app/src/main/java/com/example/ViDroidCall_Studio/MainActivity.kt
+++ b/app/src/main/java/com/example/ViDroidCall_Studio/MainActivity.kt
@@ -3,6 +3,7 @@
 
 package com.example.ViDroidCall_Studio
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -20,6 +21,7 @@ import com.example.ViDroidCall_Studio.navigation.AppRoot
 import com.example.ViDroidCall_Studio.ui.theme.ViDroidCallTheme
 
 class MainActivity : ComponentActivity() {
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
@@ -43,5 +45,14 @@ class MainActivity : ComponentActivity() {
                 AppRoot(modifier = Modifier.fillMaxSize())
             }
         }
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+    }
+
+    companion object {
+        const val EXTRA_OPEN_SETTINGS = "open_settings"
     }
 }

--- a/app/src/main/java/com/example/ViDroidCall_Studio/feature/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/ViDroidCall_Studio/feature/home/HomeScreen.kt
@@ -33,6 +33,7 @@ import androidx.core.content.ContextCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import com.example.ViDroidCall_Studio.MainActivity
 import com.example.ViDroidCall_Studio.data.local.feedback.NluFeedbackLogRepository
 import com.example.ViDroidCall_Studio.data.local.history.CommandHistoryRepository
 import com.example.ViDroidCall_Studio.data.nlu.NluActionDispatcher
@@ -64,6 +65,21 @@ fun HomeScreen(
     val scope = rememberCoroutineScope()
     val lifecycleOwner = LocalLifecycleOwner.current
     var selectedTab by remember { mutableStateOf(NavTab.ASSISTANT) }
+
+    fun consumeOpenSettingsTab(): Boolean {
+        val activity = context as? Activity ?: return false
+        val open = activity.intent?.getBooleanExtra(MainActivity.EXTRA_OPEN_SETTINGS, false) == true
+        if (open) {
+            activity.intent?.removeExtra(MainActivity.EXTRA_OPEN_SETTINGS)
+        }
+        return open
+    }
+
+    LaunchedEffect(Unit) {
+        if (consumeOpenSettingsTab()) {
+            selectedTab = NavTab.SETTINGS
+        }
+    }
 
     // Quản lý phản hồi giọng nói TTS (Text-To-Speech)
     val textToSpeech = rememberTextToSpeech()
@@ -129,6 +145,9 @@ fun HomeScreen(
                 hasStoragePermission = granted
                 if (granted && !nluEngineManager.isModelReady()) {
                     nluEngineManager.autoDetectAndLoadModel()
+                }
+                if (consumeOpenSettingsTab()) {
+                    selectedTab = NavTab.SETTINGS
                 }
             }
         }

--- a/app/src/main/java/com/example/ViDroidCall_Studio/feature/overlay/TroLyNoiForegroundController.kt
+++ b/app/src/main/java/com/example/ViDroidCall_Studio/feature/overlay/TroLyNoiForegroundController.kt
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 ViDroidCall Studio contributors
+
+package com.example.ViDroidCall_Studio.feature.overlay
+
+import android.content.Context
+import android.content.Intent
+import androidx.core.content.ContextCompat
+import com.example.ViDroidCall_Studio.util.TroLyNoiPermissions
+
+/**
+ * Bật/tắt foreground service theo công tắc DataStore. Không tự chạy khi preference false.
+ */
+object TroLyNoiForegroundController {
+
+    fun sync(context: Context, enabled: Boolean) {
+        if (enabled && TroLyNoiPermissions.hasAllRequired(context)) {
+            start(context)
+        } else {
+            stop(context)
+        }
+    }
+
+    fun start(context: Context) {
+        val app = context.applicationContext
+        val intent = Intent(app, TroLyNoiForegroundService::class.java)
+        ContextCompat.startForegroundService(app, intent)
+    }
+
+    fun stop(context: Context) {
+        val app = context.applicationContext
+        app.stopService(Intent(app, TroLyNoiForegroundService::class.java))
+    }
+}

--- a/app/src/main/java/com/example/ViDroidCall_Studio/feature/overlay/TroLyNoiForegroundService.kt
+++ b/app/src/main/java/com/example/ViDroidCall_Studio/feature/overlay/TroLyNoiForegroundService.kt
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 ViDroidCall Studio contributors
+
+package com.example.ViDroidCall_Studio.feature.overlay
+
+import android.app.Service
+import android.content.Intent
+import android.os.IBinder
+
+/**
+ * Foreground service giữ process khi Trợ lý nổi bật.
+ * Issue này chưa ghi âm / KWS; chỉ khai báo khung service.
+ */
+class TroLyNoiForegroundService : Service() {
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        return START_STICKY
+    }
+}

--- a/app/src/main/java/com/example/ViDroidCall_Studio/feature/overlay/TroLyNoiForegroundService.kt
+++ b/app/src/main/java/com/example/ViDroidCall_Studio/feature/overlay/TroLyNoiForegroundService.kt
@@ -3,18 +3,91 @@
 
 package com.example.ViDroidCall_Studio.feature.overlay
 
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
 import android.app.Service
 import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
 import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import androidx.core.app.ServiceCompat
+import com.example.ViDroidCall_Studio.MainActivity
+import com.example.ViDroidCall_Studio.R
 
 /**
- * Foreground service giữ process khi Trợ lý nổi bật.
- * Issue này chưa ghi âm / KWS; chỉ khai báo khung service.
+ * Giữ process + thông báo “đang chờ”. Không ghi âm / KWS / overlay sheet trong issue này.
  */
 class TroLyNoiForegroundService : Service() {
+
     override fun onBind(intent: Intent?): IBinder? = null
 
+    override fun onCreate() {
+        super.onCreate()
+        createChannel()
+    }
+
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        // Chưa nghe mic khi khóa màn / chưa KWS — chỉ giữ foreground.
+        promoteToForeground()
         return START_STICKY
+    }
+
+    private fun createChannel() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        val manager = getSystemService(NotificationManager::class.java) ?: return
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            "Trợ lý nổi",
+            NotificationManager.IMPORTANCE_DEFAULT,
+        ).apply {
+            description = "Thông báo khi Trợ lý nổi đang chờ lệnh"
+            setShowBadge(false)
+        }
+        manager.createNotificationChannel(channel)
+    }
+
+    private fun promoteToForeground() {
+        val notification = buildWaitingNotification()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            ServiceCompat.startForeground(
+                this,
+                NOTIFICATION_ID,
+                notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE,
+            )
+        } else {
+            startForeground(NOTIFICATION_ID, notification)
+        }
+    }
+
+    private fun buildWaitingNotification(): Notification {
+        val contentIntent = Intent(this, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            putExtra(MainActivity.EXTRA_OPEN_SETTINGS, true)
+        }
+        val pending = PendingIntent.getActivity(
+            this,
+            0,
+            contentIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+        return NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(R.mipmap.ic_launcher)
+            .setContentTitle("ViDroidCall đang chờ: Trợ lý ơi")
+            .setContentText("Bấm để mở Cài đặt. Tắt công tắc Trợ lý nổi để dừng.")
+            .setContentIntent(pending)
+            .setOngoing(true)
+            .setOnlyAlertOnce(true)
+            .setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .build()
+    }
+
+    companion object {
+        const val CHANNEL_ID = "tro_ly_noi_waiting"
+        const val NOTIFICATION_ID = 51
     }
 }

--- a/app/src/main/java/com/example/ViDroidCall_Studio/navigation/AppRoot.kt
+++ b/app/src/main/java/com/example/ViDroidCall_Studio/navigation/AppRoot.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -15,6 +16,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.compose.rememberNavController
 import com.example.ViDroidCall_Studio.data.local.OnboardingPreferences
+import com.example.ViDroidCall_Studio.data.local.TroLyNoiPreferences
+import com.example.ViDroidCall_Studio.feature.overlay.TroLyNoiForegroundController
 
 @Composable
 fun AppRoot(
@@ -22,8 +25,15 @@ fun AppRoot(
 ) {
     val context = LocalContext.current
     val onboardingPreferences = remember { OnboardingPreferences(context) }
+    val troLyNoiPreferences = remember { TroLyNoiPreferences(context) }
     val hasCompletedOnboarding by onboardingPreferences.hasCompletedOnboarding
         .collectAsState(initial = null)
+    val troLyNoiEnabled by troLyNoiPreferences.enabledFlow.collectAsState(initial = null)
+
+    LaunchedEffect(troLyNoiEnabled) {
+        val enabled = troLyNoiEnabled ?: return@LaunchedEffect
+        TroLyNoiForegroundController.sync(context, enabled)
+    }
 
     when (hasCompletedOnboarding) {
         null -> {


### PR DESCRIPTION
## Issue
Closes #51

## Thay đổi
- Khai báo foreground service type `microphone` (`TroLyNoiForegroundService`)
- Thông báo thường trực: “ViDroidCall đang chờ: Trợ lý ơi” (không vuốt tắt)
- Công tắc Trợ lý nổi ON (đã đủ quyền) → start service; OFF / thiếu quyền → stop, gỡ thông báo
- Preference `false`: mở app không start service
- Bấm thông báo → mở tab Cài đặt
- Chưa ghi âm / KWS / overlay sheet

## Ngoài phạm vi
- Wake word “Trợ lý ơi”
- STT / NLU / sheet overlay (#50)
- Màn hình khóa, tự chạy lúc boot, tối ưu pin OEM

## Kiểm tra
- [x] `./gradlew testDebugUnitTest`
- [x] Công tắc OFF: không thông báo, không service
- [x] Gạt ON (đủ quyền #49): có thông báo đang chờ
- [x] Về Home: thông báo còn
- [x] Gạt OFF: hết thông báo
- [x] Bấm thông báo: vào Cài đặt
- [x] Không tự chạy khi mở app nếu công tắc tắt