### PR TITLE
Match the overlay permission prompt to the other permission cards.

### DIFF
--- a/app/src/main/java/com/example/ViDroidCall_Studio/feature/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/example/ViDroidCall_Studio/feature/settings/SettingsScreen.kt
@@ -81,6 +81,7 @@ import com.example.ViDroidCall_Studio.data.local.FontSizePreferences
 import com.example.ViDroidCall_Studio.data.local.ThemePreferences
 import com.example.ViDroidCall_Studio.data.local.TroLyNoiPreferences
 import com.example.ViDroidCall_Studio.ui.component.IosStyleSwitch
+import com.example.ViDroidCall_Studio.ui.component.OverlayPermissionDialog
 import com.example.ViDroidCall_Studio.util.TroLyNoiPermissions
 import com.example.ViDroidCall_Studio.data.local.feedback.NluFeedbackEntry
 import com.example.ViDroidCall_Studio.data.local.feedback.NluFeedbackLogRepository
@@ -241,48 +242,26 @@ fun SettingsScreen(
     }
 
     if (showOverlayPermissionDialog) {
-        AlertDialog(
-            onDismissRequest = {
+        OverlayPermissionDialog(
+            onOpenSettings = {
                 showOverlayPermissionDialog = false
-                Toast.makeText(context, "Chưa cho phép hiện trên ứng dụng khác, Trợ lý nổi vẫn tắt", Toast.LENGTH_SHORT).show()
+                awaitingOverlaySettings = true
+                try {
+                    context.startActivity(TroLyNoiPermissions.overlaySettingsIntent(context))
+                } catch (_: Exception) {
+                    awaitingOverlaySettings = false
+                    Toast.makeText(context, "Không mở được Cài đặt quyền overlay", Toast.LENGTH_SHORT).show()
+                    disableTroLyNoi()
+                }
+            },
+            onDismiss = {
+                showOverlayPermissionDialog = false
+                Toast.makeText(
+                    context,
+                    "Chưa cho phép hiện trên ứng dụng khác, Trợ lý nổi vẫn tắt",
+                    Toast.LENGTH_SHORT
+                ).show()
                 disableTroLyNoi()
-            },
-            title = { Text("Hiện trên ứng dụng khác") },
-            text = {
-                Text(
-                    "Để bảng Trợ lý nổi hiện trên màn hình chính, hãy cho phép ViDroidCall hiển thị trên các ứng dụng khác.\n\n" +
-                        "1. Nhấn \"Mở Cài đặt\".\n" +
-                        "2. Bật quyền cho ViDroidCall.\n" +
-                        "3. Quay lại ứng dụng."
-                )
-            },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        showOverlayPermissionDialog = false
-                        awaitingOverlaySettings = true
-                        try {
-                            context.startActivity(TroLyNoiPermissions.overlaySettingsIntent(context))
-                        } catch (_: Exception) {
-                            awaitingOverlaySettings = false
-                            Toast.makeText(context, "Không mở được Cài đặt quyền overlay", Toast.LENGTH_SHORT).show()
-                            disableTroLyNoi()
-                        }
-                    }
-                ) {
-                    Text("Mở Cài đặt")
-                }
-            },
-            dismissButton = {
-                TextButton(
-                    onClick = {
-                        showOverlayPermissionDialog = false
-                        Toast.makeText(context, "Chưa cho phép hiện trên ứng dụng khác, Trợ lý nổi vẫn tắt", Toast.LENGTH_SHORT).show()
-                        disableTroLyNoi()
-                    }
-                ) {
-                    Text("Hủy")
-                }
             }
         )
     }

--- a/app/src/main/java/com/example/ViDroidCall_Studio/ui/component/OverlayPermissionDialog.kt
+++ b/app/src/main/java/com/example/ViDroidCall_Studio/ui/component/OverlayPermissionDialog.kt
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 ViDroidCall Studio contributors
+
+package com.example.ViDroidCall_Studio.ui.component
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Layers
+import androidx.compose.material.icons.rounded.Settings
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.example.ViDroidCall_Studio.ui.theme.AppPrimary
+
+/**
+ * Hộp thoại hướng dẫn cấp quyền hiện trên ứng dụng khác — cùng layout với Micro / Danh bạ / Bộ nhớ.
+ */
+@Composable
+fun OverlayPermissionDialog(
+    onOpenSettings: () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val parentDensity = LocalDensity.current
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(
+            dismissOnBackPress = true,
+            dismissOnClickOutside = false,
+            usePlatformDefaultWidth = false
+        )
+    ) {
+        CompositionLocalProvider(LocalDensity provides parentDensity) {
+            Surface(
+                modifier = modifier
+                    .fillMaxWidth(0.92f)
+                    .shadow(
+                        elevation = 16.dp,
+                        shape = RoundedCornerShape(28.dp),
+                        spotColor = AppPrimary.copy(alpha = 0.25f)
+                    ),
+                shape = RoundedCornerShape(28.dp),
+                color = MaterialTheme.colorScheme.surface,
+                border = BorderStroke(2.dp, AppPrimary)
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(24.dp)
+                        .verticalScroll(rememberScrollState()),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .size(64.dp)
+                            .background(
+                                brush = Brush.radialGradient(
+                                    colors = listOf(
+                                        AppPrimary.copy(alpha = 0.25f),
+                                        AppPrimary.copy(alpha = 0.08f)
+                                    )
+                                ),
+                                shape = CircleShape
+                            ),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Icon(
+                            imageVector = Icons.Rounded.Layers,
+                            contentDescription = null,
+                            tint = AppPrimary,
+                            modifier = Modifier.size(32.dp)
+                        )
+                    }
+
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    Text(
+                        text = "Cần quyền hiện trên ứng dụng khác",
+                        style = MaterialTheme.typography.titleLarge.copy(
+                            fontSize = 20.sp,
+                            fontWeight = FontWeight.Bold
+                        ),
+                        color = MaterialTheme.colorScheme.onSurface,
+                        textAlign = TextAlign.Center
+                    )
+
+                    Spacer(modifier = Modifier.height(10.dp))
+
+                    Text(
+                        text = "Để bảng Trợ lý nổi hiện trên màn hình chính, hãy cho phép ViDroidCall hiển thị trên các ứng dụng khác.",
+                        style = MaterialTheme.typography.bodyMedium.copy(
+                            fontSize = 14.5.sp,
+                            lineHeight = 22.sp
+                        ),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        textAlign = TextAlign.Center
+                    )
+
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    Surface(
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = RoundedCornerShape(16.dp),
+                        color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.35f),
+                        border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary.copy(alpha = 0.15f))
+                    ) {
+                        Column(
+                            modifier = Modifier.padding(14.dp),
+                            verticalArrangement = Arrangement.spacedBy(6.dp)
+                        ) {
+                            Text(
+                                text = "📋 Hướng dẫn cấp quyền:",
+                                style = MaterialTheme.typography.bodyMedium.copy(
+                                    fontWeight = FontWeight.SemiBold,
+                                    fontSize = 14.sp
+                                ),
+                                color = MaterialTheme.colorScheme.primary
+                            )
+                            Text(
+                                text = "1. Nhấn nút \"Mở Cài đặt ứng dụng\" bên dưới.\n2. Bật công tắc cho phép ViDroidCall hiển thị trên các ứng dụng khác.\n3. Quay lại ứng dụng.",
+                                style = MaterialTheme.typography.bodyMedium.copy(
+                                    fontSize = 14.sp,
+                                    fontWeight = FontWeight.Medium,
+                                    lineHeight = 20.sp
+                                ),
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+
+                    Spacer(modifier = Modifier.height(22.dp))
+
+                    Column(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalArrangement = Arrangement.spacedBy(10.dp)
+                    ) {
+                        Button(
+                            onClick = onOpenSettings,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(48.dp),
+                            shape = RoundedCornerShape(14.dp),
+                            colors = ButtonDefaults.buttonColors(
+                                containerColor = AppPrimary,
+                                contentColor = Color.White
+                            )
+                        ) {
+                            Icon(
+                                imageVector = Icons.Rounded.Settings,
+                                contentDescription = null,
+                                modifier = Modifier.size(18.dp)
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text(
+                                text = "Mở Cài đặt ứng dụng",
+                                style = MaterialTheme.typography.labelLarge.copy(
+                                    fontSize = 15.sp,
+                                    fontWeight = FontWeight.SemiBold
+                                )
+                            )
+                        }
+
+                        OutlinedButton(
+                            onClick = onDismiss,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(48.dp),
+                            shape = RoundedCornerShape(14.dp),
+                            border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.35f))
+                        ) {
+                            Text(
+                                text = "Để sau",
+                                style = MaterialTheme.typography.labelLarge.copy(
+                                    fontSize = 15.sp,
+                                    fontWeight = FontWeight.Normal
+                                ),
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Issue
Follow-up #49 (không đóng lại)

## Thay đổi
- Thay `AlertDialog` hệ thống bằng `OverlayPermissionDialog` cùng layout với hộp Micro / Danh bạ / Bộ nhớ
- Có icon, tiêu đề, mô tả, khung hướng dẫn 3 bước, nút **Mở Cài đặt ứng dụng** và **Để sau**
- Giữ nguyên luồng: Mở Cài đặt overlay → resume đủ quyền thì bật; Hủy / back thì Trợ lý nổi về OFF

## Ngoài phạm vi
- Thay đổi thứ tự xin quyền mic / thông báo / overlay
- Overlay sheet (#50)
- Wake word, STT, NLU

## Kiểm tra
- [x] `./gradlew testDebugUnitTest`
- [x] Gạt ON Trợ lý nổi (thiếu overlay): hộp mới hiện, không còn dialog hệ thống
- [x] **Mở Cài đặt ứng dụng**: vào màn hiện trên ứng dụng khác
- [x] Bật quyền rồi quay lại: công tắc ON
- [x] **Để sau** / Back: công tắc OFF