### PR TITLE
feat(overlay): trien khai tro ly noi overlay bottom sheet va nut thu …

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -65,6 +65,14 @@
             android:foregroundServiceType="microphone" />
 
         <activity
+            android:name=".feature.overlay.TroLyNoiOverlayActivity"
+            android:exported="true"
+            android:theme="@style/Theme.ViDroidCall.Translucent"
+            android:launchMode="singleTop"
+            android:excludeFromRecents="true"
+            android:windowSoftInputMode="adjustResize" />
+
+        <activity
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/app_name"

--- a/app/src/main/java/com/example/ViDroidCall_Studio/feature/overlay/TroLyNoSheet.kt
+++ b/app/src/main/java/com/example/ViDroidCall_Studio/feature/overlay/TroLyNoSheet.kt
@@ -1,0 +1,725 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 ViDroidCall Studio contributors
+
+package com.example.ViDroidCall_Studio.feature.overlay
+
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.Message
+import androidx.compose.material.icons.rounded.Call
+import androidx.compose.material.icons.rounded.Check
+import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material.icons.rounded.Mic
+import androidx.compose.material.icons.rounded.Navigation
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.ViDroidCall_Studio.domain.model.NativeAction
+
+/**
+ * Hộp thoại Trợ lý nổi (Overlay Bottom Sheet)
+ * Render hộp thoại trợ lý ảo bám đáy (bottom-pinned) theo thiết kế Stitch.
+ * Tuyệt đối KHÔNG chứa fake HomeScreen hay wallpaper giả.
+ */
+@Composable
+fun TroLyNoSheet(
+    state: TroLyNoState,
+    onConfirm: () -> Unit,
+    onCancel: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    // Chuẩn thiết kế Stitch: Frosted white glassmorphism card
+    val cardBackground = Color(0xF5FFFFFF)
+    val cardBorder = Color.White.copy(alpha = 0.8f)
+    val textPrimary = Color(0xFF0F172A)
+    val textSecondary = Color(0xFF475569)
+
+    Surface(
+        modifier = modifier
+            .fillMaxWidth()
+            .widthIn(max = 600.dp)
+            .shadow(
+                elevation = 20.dp,
+                shape = RoundedCornerShape(28.dp),
+                spotColor = Color(0x35000000)
+            ),
+        shape = RoundedCornerShape(28.dp),
+        color = cardBackground,
+        border = BorderStroke(1.dp, cardBorder)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            // 1. Header row: Branding & status badge
+            HeaderRow(state = state, textPrimary = textPrimary, textSecondary = textSecondary)
+
+            // 2. Nội dung theo từng trạng thái (Listening, STT, FastPath, Analyzing, Confirmation, Clarify)
+            when (state) {
+                is TroLyNoState.Listening -> {
+                    ListeningContent(
+                        textPrimary = textPrimary,
+                        textSecondary = textSecondary
+                    )
+                }
+
+                is TroLyNoState.Stt -> {
+                    SttContent(
+                        transcript = state.text,
+                        textPrimary = textPrimary,
+                        textSecondary = textSecondary
+                    )
+                }
+
+                is TroLyNoState.FastPath -> {
+                    FastPathContent(
+                        text = state.text,
+                        action = state.action,
+                        textPrimary = textPrimary,
+                        textSecondary = textSecondary
+                    )
+                }
+
+                is TroLyNoState.Analyzing -> {
+                    AnalyzingContent(
+                        text = "Đang nhận diện...",
+                        textPrimary = textPrimary,
+                        textSecondary = textSecondary
+                    )
+                }
+
+                is TroLyNoState.Confirmation -> {
+                    ConfirmationContent(
+                        action = state.action,
+                        onConfirm = onConfirm,
+                        onCancel = onCancel,
+                        textPrimary = textPrimary,
+                        textSecondary = textSecondary
+                    )
+                }
+
+                is TroLyNoState.Clarify -> {
+                    ClarifyContent(
+                        text = state.text,
+                        missing = state.missing,
+                        onCancel = onCancel,
+                        textPrimary = textPrimary,
+                        textSecondary = textSecondary
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Thanh tiêu đề thương hiệu ViDroidCall và Status Pill
+ */
+@Composable
+private fun HeaderRow(
+    state: TroLyNoState,
+    textPrimary: Color,
+    textSecondary: Color
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        // Logo & Tên ứng dụng
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(8.dp)
+                    .background(Color(0xFF0866FF), CircleShape)
+            )
+            Box(
+                modifier = Modifier
+                    .size(24.dp)
+                    .background(Color(0xFF0866FF), RoundedCornerShape(7.dp)),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.Mic,
+                    contentDescription = null,
+                    tint = Color.White,
+                    modifier = Modifier.size(14.dp)
+                )
+            }
+            Text(
+                text = "ViDroidCall",
+                fontSize = 14.sp,
+                fontWeight = FontWeight.Bold,
+                color = textPrimary,
+                letterSpacing = (-0.2).sp
+            )
+        }
+
+        // Status Badge Pill
+        when (state) {
+            is TroLyNoState.Listening, is TroLyNoState.Stt -> {
+                Surface(
+                    shape = CircleShape,
+                    color = Color(0xFFD1FAE5),
+                    border = BorderStroke(1.dp, Color(0xFFA7F3D0))
+                ) {
+                    Row(
+                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(6.dp)
+                    ) {
+                        PulsingIndicator(color = Color(0xFF10B981))
+                        Text(
+                            text = "Trợ lý AI đã sẵn sàng",
+                            fontSize = 12.sp,
+                            fontWeight = FontWeight.SemiBold,
+                            color = Color(0xFF065F46)
+                        )
+                    }
+                }
+            }
+
+            is TroLyNoState.FastPath -> {
+                Surface(
+                    shape = CircleShape,
+                    color = Color(0xFFDBEAFE),
+                    border = BorderStroke(1.dp, Color(0xFFBFDBFE))
+                ) {
+                    Text(
+                        text = "⚡ Khớp tức thì",
+                        fontSize = 12.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = Color(0xFF0866FF),
+                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp)
+                    )
+                }
+            }
+
+            is TroLyNoState.Analyzing -> {
+                Surface(
+                    shape = CircleShape,
+                    color = Color(0xFFEFF6FF),
+                    border = BorderStroke(1.dp, Color(0xFFDBEAFE))
+                ) {
+                    Text(
+                        text = "Đang phân tích",
+                        fontSize = 12.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        color = Color(0xFF0866FF),
+                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp)
+                    )
+                }
+            }
+
+            is TroLyNoState.Confirmation -> {
+                Surface(
+                    shape = CircleShape,
+                    color = Color(0xFFEFF6FF),
+                    border = BorderStroke(1.dp, Color(0xFFDBEAFE))
+                ) {
+                    Text(
+                        text = "Xác nhận",
+                        fontSize = 12.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = Color(0xFF0866FF),
+                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp)
+                    )
+                }
+            }
+
+            is TroLyNoState.Clarify -> {
+                Surface(
+                    shape = CircleShape,
+                    color = Color(0xFFFEF3C7),
+                    border = BorderStroke(1.dp, Color(0xFFFDE68A))
+                ) {
+                    Text(
+                        text = "Cần làm rõ",
+                        fontSize = 12.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        color = Color(0xFF92400E),
+                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp)
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Trạng thái Listening: hiển thị tiêu đề, waveform, phụ đề hướng dẫn
+ */
+@Composable
+private fun ListeningContent(
+    textPrimary: Color,
+    textSecondary: Color
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "Đang lắng nghe câu lệnh...",
+                fontSize = 20.sp,
+                fontWeight = FontWeight.Bold,
+                color = textPrimary,
+                modifier = Modifier.weight(1f)
+            )
+            SoundWaveAnimation()
+        }
+        Text(
+            text = "Hãy nói gì đó...",
+            fontSize = 16.sp,
+            fontWeight = FontWeight.Medium,
+            color = textSecondary
+        )
+    }
+}
+
+/**
+ * Trạng thái STT: hiển thị transcript hiện tại cập nhật theo thời gian thực
+ */
+@Composable
+private fun SttContent(
+    transcript: String,
+    textPrimary: Color,
+    textSecondary: Color
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = if (transcript.isNotBlank()) "“$transcript”" else "Đang lắng nghe...",
+                fontSize = 20.sp,
+                fontWeight = FontWeight.Bold,
+                color = textPrimary,
+                modifier = Modifier.weight(1f),
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+            SoundWaveAnimation()
+        }
+        Text(
+            text = "Đang nhận diện giọng nói...",
+            fontSize = 16.sp,
+            fontWeight = FontWeight.Medium,
+            color = textSecondary
+        )
+    }
+}
+
+/**
+ * Trạng thái Fast-Path: khớp nhanh quy tắc
+ */
+@Composable
+private fun FastPathContent(
+    text: String,
+    action: NativeAction,
+    textPrimary: Color,
+    textSecondary: Color
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Text(
+            text = "ĐÃ NHẬN DIỆN",
+            fontSize = 11.sp,
+            fontWeight = FontWeight.SemiBold,
+            color = textSecondary,
+            letterSpacing = 0.5.sp
+        )
+        Text(
+            text = "“$text”",
+            fontSize = 22.sp,
+            fontWeight = FontWeight.ExtraBold,
+            color = textPrimary
+        )
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.padding(top = 4.dp)
+        ) {
+            Surface(
+                shape = RoundedCornerShape(10.dp),
+                color = Color(0xFFEFF6FF),
+                border = BorderStroke(1.dp, Color(0xFFBFDBFE))
+            ) {
+                Text(
+                    text = "⚡ Fast-Path (Bộ dữ liệu)",
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = Color(0xFF0866FF),
+                    modifier = Modifier.padding(horizontal = 10.dp, vertical = 5.dp)
+                )
+            }
+            Surface(
+                shape = RoundedCornerShape(10.dp),
+                color = Color(0xFFF1F5F9),
+                border = BorderStroke(1.dp, Color(0xFFCBD5E1))
+            ) {
+                Text(
+                    text = "Intent: ${action.intentName}",
+                    fontSize = 11.sp,
+                    fontFamily = FontFamily.Monospace,
+                    fontWeight = FontWeight.SemiBold,
+                    color = Color(0xFF334155),
+                    modifier = Modifier.padding(horizontal = 10.dp, vertical = 5.dp)
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Trạng thái Analyzing: AI đang phân tích câu lệnh
+ */
+@Composable
+private fun AnalyzingContent(
+    text: String,
+    textPrimary: Color,
+    textSecondary: Color
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        Text(
+            text = "ĐÃ NHẬN DIỆN",
+            fontSize = 11.sp,
+            fontWeight = FontWeight.SemiBold,
+            color = textSecondary,
+            letterSpacing = 0.5.sp
+        )
+        Text(
+            text = "“$text”",
+            fontSize = 20.sp,
+            fontWeight = FontWeight.Bold,
+            color = textPrimary,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis
+        )
+        Surface(
+            shape = RoundedCornerShape(16.dp),
+            color = Color(0xFFEFF6FF),
+            border = BorderStroke(1.dp, Color(0xFFDBEAFE)),
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 14.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(22.dp),
+                    color = Color(0xFF0866FF),
+                    strokeWidth = 2.5.dp
+                )
+                Text(
+                    text = "AI đang phân tích câu lệnh...",
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = Color(0xFF1E293B)
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Trạng thái Confirmation: Hộp thoại xác nhận trước khi thực thi cuộc gọi, gửi SMS, v.v.
+ */
+@Composable
+private fun ConfirmationContent(
+    action: NativeAction,
+    onConfirm: () -> Unit,
+    onCancel: () -> Unit,
+    textPrimary: Color,
+    textSecondary: Color
+) {
+    val actionIcon = when (action) {
+        is NativeAction.CallContact -> Icons.Rounded.Call
+        is NativeAction.SendSms -> Icons.AutoMirrored.Rounded.Message
+        is NativeAction.OpenMap -> Icons.Rounded.Navigation
+        else -> Icons.Rounded.Check
+    }
+
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        Text(
+            text = action.getConfirmationTitle(),
+            fontSize = 21.sp,
+            fontWeight = FontWeight.ExtraBold,
+            color = textPrimary,
+            lineHeight = 28.sp
+        )
+        Text(
+            text = action.getConfirmationDescription(),
+            fontSize = 16.sp,
+            fontWeight = FontWeight.Medium,
+            color = textSecondary,
+            lineHeight = 22.sp
+        )
+
+        if (action is NativeAction.SendSms && action.message.isNotBlank()) {
+            Surface(
+                shape = RoundedCornerShape(12.dp),
+                color = Color(0xFFF8FAFC),
+                border = BorderStroke(1.dp, Color(0xFFE2E8F0)),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(
+                    text = "“${action.message}”",
+                    fontSize = 15.sp,
+                    fontStyle = FontStyle.Italic,
+                    color = textPrimary,
+                    modifier = Modifier.padding(12.dp)
+                )
+            }
+        }
+
+        // Action Buttons: Hủy & Xác nhận
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 4.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Button(
+                onClick = onCancel,
+                modifier = Modifier
+                    .weight(1f)
+                    .height(52.dp),
+                shape = RoundedCornerShape(16.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = Color(0xFFE2E8F0),
+                    contentColor = Color(0xFF1E293B)
+                ),
+                elevation = ButtonDefaults.buttonElevation(defaultElevation = 0.dp)
+            ) {
+                Text(
+                    text = "Hủy",
+                    fontSize = 17.sp,
+                    fontWeight = FontWeight.Bold
+                )
+            }
+
+            Button(
+                onClick = onConfirm,
+                modifier = Modifier
+                    .weight(1f)
+                    .height(52.dp),
+                shape = RoundedCornerShape(16.dp),
+                contentPadding = PaddingValues(horizontal = 8.dp, vertical = 0.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = Color(0xFF0866FF),
+                    contentColor = Color.White
+                ),
+                elevation = ButtonDefaults.buttonElevation(defaultElevation = 2.dp)
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(6.dp)
+                ) {
+                    Icon(
+                        imageVector = actionIcon,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp)
+                    )
+                    Text(
+                        text = "Xác nhận",
+                        fontSize = 16.sp,
+                        fontWeight = FontWeight.Bold,
+                        maxLines = 1
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Trạng thái Clarify: làm rõ thông tin
+ */
+@Composable
+private fun ClarifyContent(
+    text: String,
+    missing: List<String>,
+    onCancel: () -> Unit,
+    textPrimary: Color,
+    textSecondary: Color
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        Text(
+            text = "Cần thêm thông tin",
+            fontSize = 20.sp,
+            fontWeight = FontWeight.Bold,
+            color = textPrimary
+        )
+        Text(
+            text = text,
+            fontSize = 16.sp,
+            color = textSecondary
+        )
+        if (missing.isNotEmpty()) {
+            Text(
+                text = "Thông tin còn thiếu: ${missing.joinToString(", ")}",
+                fontSize = 14.sp,
+                fontWeight = FontWeight.Medium,
+                color = Color(0xFFB45309)
+            )
+        }
+        Button(
+            onClick = onCancel,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(48.dp),
+            shape = RoundedCornerShape(14.dp),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = Color(0xFFE2E8F0),
+                contentColor = Color(0xFF1E293B)
+            )
+        ) {
+            Text(text = "Đóng", fontWeight = FontWeight.Bold)
+        }
+    }
+}
+
+/**
+ * Chấm tròn nhấp nháy chỉ báo trạng thái hoạt động
+ */
+@Composable
+private fun PulsingIndicator(color: Color) {
+    val transition = rememberInfiniteTransition(label = "Pulse")
+    val alpha = transition.animateFloat(
+        initialValue = 0.4f,
+        targetValue = 1.0f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(800, easing = FastOutSlowInEasing),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "Alpha"
+    )
+    Box(
+        modifier = Modifier
+            .size(6.dp)
+            .background(color.copy(alpha = alpha.value), CircleShape)
+    )
+}
+
+/**
+ * Waveform 5 thanh sóng âm thanh chuyển động nhịp nhàng theo phong cách Stitch
+ */
+@Composable
+private fun SoundWaveAnimation() {
+    val infiniteTransition = rememberInfiniteTransition(label = "SoundWave")
+    val h1 = infiniteTransition.animateFloat(
+        initialValue = 10f, targetValue = 26f,
+        animationSpec = infiniteRepeatable(tween(600, easing = FastOutSlowInEasing), RepeatMode.Reverse),
+        label = "h1"
+    )
+    val h2 = infiniteTransition.animateFloat(
+        initialValue = 22f, targetValue = 12f,
+        animationSpec = infiniteRepeatable(tween(750, delayMillis = 150, easing = FastOutSlowInEasing), RepeatMode.Reverse),
+        label = "h2"
+    )
+    val h3 = infiniteTransition.animateFloat(
+        initialValue = 14f, targetValue = 28f,
+        animationSpec = infiniteRepeatable(tween(550, delayMillis = 300, easing = FastOutSlowInEasing), RepeatMode.Reverse),
+        label = "h3"
+    )
+    val h4 = infiniteTransition.animateFloat(
+        initialValue = 24f, targetValue = 14f,
+        animationSpec = infiniteRepeatable(tween(800, delayMillis = 100, easing = FastOutSlowInEasing), RepeatMode.Reverse),
+        label = "h4"
+    )
+    val h5 = infiniteTransition.animateFloat(
+        initialValue = 10f, targetValue = 20f,
+        animationSpec = infiniteRepeatable(tween(650, delayMillis = 200, easing = FastOutSlowInEasing), RepeatMode.Reverse),
+        label = "h5"
+    )
+
+    val heights = listOf(h1, h2, h3, h4, h5)
+    val colors = listOf(
+        Color(0xFF0866FF),
+        Color(0xFF6EA2FF),
+        Color(0xFF0866FF),
+        Color(0xFFA9C9FF),
+        Color(0xFF6EA2FF)
+    )
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(3.dp),
+        modifier = Modifier
+            .height(30.dp)
+            .padding(horizontal = 4.dp)
+    ) {
+        heights.forEachIndexed { index, anim ->
+            Box(
+                modifier = Modifier
+                    .width(4.dp)
+                    .height(anim.value.dp)
+                    .background(colors[index], CircleShape)
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/ViDroidCall_Studio/feature/overlay/TroLyNoState.kt
+++ b/app/src/main/java/com/example/ViDroidCall_Studio/feature/overlay/TroLyNoState.kt
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 ViDroidCall Studio contributors
+
+package com.example.ViDroidCall_Studio.feature.overlay
+
+import com.example.ViDroidCall_Studio.domain.model.NativeAction
+
+/**
+ * Trạng thái của Hộp thoại Trợ lý nổi (TroLyNoSheet)
+ */
+sealed interface TroLyNoState {
+
+    /**
+     * Đang lắng nghe âm thanh từ microphone
+     */
+    data object Listening : TroLyNoState
+
+    /**
+     * Đang nhận diện giọng nói (STT) và hiển thị transcript theo thời gian thực
+     */
+    data class Stt(
+        val text: String
+    ) : TroLyNoState
+
+    /**
+     * Khớp tức thì với Fast-Path (< 5ms), không cần chờ mô hình AI suy luận
+     */
+    data class FastPath(
+        val text: String,
+        val action: NativeAction
+    ) : TroLyNoState
+
+    /**
+     * Đang phân tích câu lệnh bằng mô hình AI on-device (GGUF)
+     */
+    data object Analyzing : TroLyNoState
+
+    /**
+     * Hộp thoại xác nhận trước khi thực thi các hành động nhạy cảm (call_contact, send_sms, v.v.)
+     */
+    data class Confirmation(
+        val text: String,
+        val action: NativeAction
+    ) : TroLyNoState
+
+    /**
+     * Cần người dùng làm rõ thêm thông tin còn thiếu
+     */
+    data class Clarify(
+        val text: String,
+        val missing: List<String>
+    ) : TroLyNoState
+}

--- a/app/src/main/java/com/example/ViDroidCall_Studio/feature/overlay/TroLyNoiForegroundController.kt
+++ b/app/src/main/java/com/example/ViDroidCall_Studio/feature/overlay/TroLyNoiForegroundController.kt
@@ -31,4 +31,21 @@ object TroLyNoiForegroundController {
         val app = context.applicationContext
         app.stopService(Intent(app, TroLyNoiForegroundService::class.java))
     }
+
+    /**
+     * Mở giao diện Trợ lý nổi (Overlay Bottom Sheet) nếu thiết bị đã mở khóa.
+     */
+    fun openOverlay(context: Context) {
+        if (isDeviceLocked(context)) return
+        val intent = TroLyNoiOverlayActivity.createIntent(context)
+        context.startActivity(intent)
+    }
+
+    /**
+     * Kiểm tra xem màn hình thiết bị có đang bị khóa bởi Keyguard hay không.
+     */
+    fun isDeviceLocked(context: Context): Boolean {
+        val keyguardManager = context.getSystemService(Context.KEYGUARD_SERVICE) as? android.app.KeyguardManager
+        return keyguardManager?.isKeyguardLocked == true
+    }
 }

--- a/app/src/main/java/com/example/ViDroidCall_Studio/feature/overlay/TroLyNoiOverlayActivity.kt
+++ b/app/src/main/java/com/example/ViDroidCall_Studio/feature/overlay/TroLyNoiOverlayActivity.kt
@@ -1,0 +1,358 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 ViDroidCall Studio contributors
+
+package com.example.ViDroidCall_Studio.feature.overlay
+
+import android.Manifest
+import android.app.KeyguardManager
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.content.pm.PackageManager
+import android.os.Bundle
+import android.util.Log
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.BackHandler
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
+import com.example.ViDroidCall_Studio.data.nlu.FastPathMatcher
+import com.example.ViDroidCall_Studio.data.nlu.NluActionDispatcher
+import com.example.ViDroidCall_Studio.data.nlu.NluEngineManager
+import com.example.ViDroidCall_Studio.domain.model.NativeAction
+import com.example.ViDroidCall_Studio.feature.speech.SpeechToTextManager
+import com.example.ViDroidCall_Studio.feature.speech.TextToSpeechManager
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+/**
+ * Overlay Host: Hiển thị Trợ lý nổi trên nền trong suốt trên toàn hệ thống.
+ * Cửa sổ thực sự trong suốt, hiển thị toàn bộ app thật phía sau.
+ * Chỉ hiển thị khi thiết bị đã được mở khóa (unlocked).
+ */
+class TroLyNoiOverlayActivity : ComponentActivity() {
+
+    private var onNewCommandCallback: ((String) -> Unit)? = null
+
+    private val screenReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            if (intent?.action == Intent.ACTION_SCREEN_OFF) {
+                // Đóng overlay ngay khi màn hình tắt/khóa
+                finish()
+            }
+        }
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        val cmd = intent.getStringExtra(EXTRA_COMMAND)
+        if (!cmd.isNullOrBlank()) {
+            onNewCommandCallback?.invoke(cmd)
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        // 1. Kiểm tra trạng thái khóa màn hình: nếu đang khóa thì lập tức đóng
+        if (isDeviceLocked()) {
+            Log.w(TAG, "Thiết bị đang khóa màn hình. Không hiển thị Trợ lý nổi.")
+            finish()
+            return
+        }
+
+        val filter = IntentFilter(Intent.ACTION_SCREEN_OFF)
+        registerReceiver(screenReceiver, filter)
+
+        enableEdgeToEdge()
+
+        setContent {
+            val scope = rememberCoroutineScope()
+            var state by remember { mutableStateOf<TroLyNoState>(TroLyNoState.Listening) }
+            val fastPathMatcher = remember { FastPathMatcher(applicationContext) }
+            val nluEngineManager = remember { NluEngineManager(applicationContext) }
+
+            var textToSpeechRef by remember { mutableStateOf<TextToSpeechManager?>(null) }
+            val textToSpeech = remember {
+                TextToSpeechManager(applicationContext).also { textToSpeechRef = it }
+            }
+
+            var actionDispatcherRef by remember { mutableStateOf<NluActionDispatcher?>(null) }
+            val actionDispatcher = remember(textToSpeech) {
+                NluActionDispatcher(
+                    context = applicationContext,
+                    enableAppLaunch = true,
+                    onActionError = {},
+                    onSpeakFeedback = { speechText ->
+                        textToSpeech.speak(speechText)
+                    }
+                ).also { actionDispatcherRef = it }
+            }
+
+            var speechManagerRef by remember { mutableStateOf<SpeechToTextManager?>(null) }
+
+            // Xử lý câu lệnh sau khi STT nhận dạng thành công
+            fun processCommand(query: String) {
+                val cleanQuery = query.trim()
+                if (cleanQuery.isEmpty()) return
+
+                // 1. Kiểm tra Fast-Path trước (< 5ms, Zero-LLM)
+                val fastResult = fastPathMatcher.match(cleanQuery)
+                if (fastResult != null) {
+                    val action = NativeAction.fromNluResult(fastResult)
+                    if (action.requiresConfirmation) {
+                        // CRITICAL SAFETY RULE: Chuyển sang Confirmation, KHÔNG thực thi trước
+                        state = TroLyNoState.Confirmation(text = cleanQuery, action = action)
+                        val promptSpeech = action.getConfirmationDescription()
+                        if (promptSpeech.isNotBlank()) {
+                            textToSpeech.speak(promptSpeech)
+                        }
+                    } else {
+                        // Hành động an toàn (không cần xác nhận)
+                        state = TroLyNoState.FastPath(text = cleanQuery, action = action)
+                        val speech = action.getSpeechFeedbackText()
+                        if (speech.isNotBlank()) {
+                            textToSpeech.speak(speech)
+                        }
+                        actionDispatcher.executeNativeAction(action)
+                        scope.launch {
+                            delay(1500)
+                            finish()
+                        }
+                    }
+                    return
+                }
+
+                // 2. Không khớp Fast-Path -> Chuyển sang Analyzing và gửi vào NLU Model
+                state = TroLyNoState.Analyzing
+                nluEngineManager.processQuery(cleanQuery)
+            }
+
+            LaunchedEffect(Unit) {
+                onNewCommandCallback = { cmd ->
+                    processCommand(cmd)
+                }
+                val testCommand = intent.getStringExtra(EXTRA_COMMAND)
+                if (!testCommand.isNullOrBlank()) {
+                    processCommand(testCommand)
+                }
+            }
+
+            // Lắng nghe kết quả từ NLU Engine
+            LaunchedEffect(nluEngineManager) {
+                nluEngineManager.nluEvents.collect { result ->
+                    val query = nluEngineManager.currentQuery.value
+                    val action = NativeAction.fromNluResult(result)
+
+                    if (result.status == "success") {
+                        if (action.requiresConfirmation) {
+                            // CRITICAL SAFETY: Yêu cầu xác nhận trước khi thực thi
+                            state = TroLyNoState.Confirmation(text = query, action = action)
+                            val promptSpeech = action.getConfirmationDescription()
+                            if (promptSpeech.isNotBlank()) {
+                                textToSpeech.speak(promptSpeech)
+                            }
+                        } else {
+                            val speech = action.getSpeechFeedbackText()
+                            if (speech.isNotBlank()) {
+                                textToSpeech.speak(speech)
+                            }
+                            actionDispatcher.executeNativeAction(action)
+                            scope.launch {
+                                delay(1500)
+                                finish()
+                            }
+                        }
+                    } else if (result.status == "needs_clarification") {
+                        state = TroLyNoState.Clarify(
+                            text = query,
+                            missing = listOf("Vui lòng nêu rõ hơn yêu cầu")
+                        )
+                    } else {
+                        val speech = action.getSpeechFeedbackText()
+                        if (speech.isNotBlank()) {
+                            textToSpeech.speak(speech)
+                        }
+                        scope.launch {
+                            delay(2000)
+                            finish()
+                        }
+                    }
+                }
+            }
+
+            val permissionLauncher = rememberLauncherForActivityResult(
+                contract = ActivityResultContracts.RequestPermission()
+            ) { isGranted ->
+                if (isGranted) {
+                    speechManagerRef?.startListening()
+                } else {
+                    finish()
+                }
+            }
+
+            // Khởi tạo STT Sherpa-ONNX
+            DisposableEffect(Unit) {
+                val stt = SpeechToTextManager(
+                    context = applicationContext,
+                    callbacks = object : SpeechToTextManager.Callbacks {
+                        override fun onListeningChanged(isListening: Boolean) {
+                            if (isListening) {
+                                state = TroLyNoState.Listening
+                            }
+                        }
+
+                        override fun onTextChanged(text: String) {
+                            if (text.isNotBlank() &&
+                                text != SpeechToTextManager.LISTENING_PLACEHOLDER &&
+                                text != SpeechToTextManager.WAITING_PLACEHOLDER
+                            ) {
+                                state = TroLyNoState.Stt(text = text)
+                            }
+                        }
+
+                        override fun onFinalResult(text: String) {
+                            if (text.isNotBlank() &&
+                                text != SpeechToTextManager.LISTENING_PLACEHOLDER &&
+                                text != SpeechToTextManager.WAITING_PLACEHOLDER &&
+                                text != SpeechToTextManager.ERROR_MESSAGE &&
+                                text != SpeechToTextManager.PERMISSION_DENIED_MESSAGE
+                            ) {
+                                processCommand(text)
+                            }
+                        }
+                    }
+                )
+                speechManagerRef = stt
+
+                // Kiểm tra quyền RECORD_AUDIO trước khi lắng nghe
+                val hasPermission = ContextCompat.checkSelfPermission(
+                    this@TroLyNoiOverlayActivity,
+                    Manifest.permission.RECORD_AUDIO
+                ) == PackageManager.PERMISSION_GRANTED
+
+                if (hasPermission) {
+                    stt.startListening()
+                } else {
+                    permissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
+                }
+
+                onDispose {
+                    onNewCommandCallback = null
+                    stt.destroy()
+                    textToSpeech.shutdown()
+                }
+            }
+
+            // Xử lý nút Back của hệ thống
+            BackHandler {
+                speechManagerRef?.cancelListening()
+                textToSpeech.stop()
+                finish()
+            }
+
+            // Giao diện Overlay Host: Nền hoàn toàn trong suốt + TroLyNoSheet neo ở đáy
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color.Black.copy(alpha = 0.08f)) // Scrim nhẹ 8% tinh tế
+                    .clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null,
+                        onClick = {
+                            // Bấm vào khoảng trống trong suốt bên ngoài sheet -> đóng trợ lý
+                            speechManagerRef?.cancelListening()
+                            textToSpeech.stop()
+                            finish()
+                        }
+                    )
+            ) {
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.BottomCenter)
+                        .navigationBarsPadding()
+                        .padding(start = 16.dp, end = 16.dp, bottom = 28.dp, top = 8.dp)
+                        .clickable(
+                            interactionSource = remember { MutableInteractionSource() },
+                            indication = null,
+                            onClick = {} // Chặn click-through để không đóng sheet khi bấm vào trong hộp thoại
+                        )
+                ) {
+                    TroLyNoSheet(
+                        state = state,
+                        onConfirm = {
+                            val currentState = state
+                            if (currentState is TroLyNoState.Confirmation) {
+                                // CRITICAL SAFETY RULE: Chỉ execute sau khi user bấm Xác nhận
+                                actionDispatcher.executeNativeAction(currentState.action)
+                            }
+                            speechManagerRef?.cancelListening()
+                            textToSpeech.stop()
+                            finish()
+                        },
+                        onCancel = {
+                            // Hủy thao tác: không execute action và đóng overlay
+                            speechManagerRef?.cancelListening()
+                            textToSpeech.stop()
+                            finish()
+                        }
+                    )
+                }
+            }
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        if (isDeviceLocked()) {
+            finish()
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        try {
+            unregisterReceiver(screenReceiver)
+        } catch (e: Exception) {
+            // Đã unregister hoặc chưa đăng ký
+        }
+    }
+
+    private fun isDeviceLocked(): Boolean {
+        val keyguardManager = getSystemService(Context.KEYGUARD_SERVICE) as? KeyguardManager
+        return keyguardManager?.isKeyguardLocked == true
+    }
+
+    companion object {
+        private const val TAG = "TroLyNoiOverlay"
+        const val EXTRA_COMMAND = "command"
+
+        fun createIntent(context: Context): Intent {
+            return Intent(context, TroLyNoiOverlayActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/ViDroidCall_Studio/feature/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/example/ViDroidCall_Studio/feature/settings/SettingsScreen.kt
@@ -39,13 +39,17 @@ import androidx.compose.material.icons.rounded.Info
 import androidx.compose.material.icons.rounded.LightMode
 import androidx.compose.material.icons.rounded.Palette
 import androidx.compose.material.icons.rounded.PhoneAndroid
+import androidx.compose.material.icons.rounded.PlayArrow
 import androidx.compose.material.icons.rounded.Settings
 import androidx.compose.material.icons.rounded.GraphicEq
 import androidx.compose.material.icons.rounded.Share
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import com.example.ViDroidCall_Studio.feature.overlay.TroLyNoiForegroundController
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -730,57 +734,95 @@ fun SettingsScreen(
                 color = MaterialTheme.colorScheme.surface,
                 border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.12f))
             ) {
-                Row(
+                Column(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = 18.dp, vertical = 16.dp),
-                    verticalAlignment = Alignment.CenterVertically
+                        .padding(horizontal = 18.dp, vertical = 16.dp)
                 ) {
-                    Box(
-                        modifier = Modifier
-                            .size(36.dp)
-                            .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.12f), CircleShape),
-                        contentAlignment = Alignment.Center
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically
                     ) {
-                        Icon(
-                            imageVector = Icons.Rounded.GraphicEq,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.primary,
-                            modifier = Modifier.size(20.dp)
-                        )
-                    }
-                    Spacer(modifier = Modifier.width(12.dp))
-                    Column(modifier = Modifier.weight(1f)) {
-                        Text(
-                            text = "Trợ lý nổi",
-                            fontSize = 18.sp,
-                            fontWeight = FontWeight.Bold,
-                            color = MaterialTheme.colorScheme.onSurface
-                        )
-                        Spacer(modifier = Modifier.height(4.dp))
-                        Text(
-                            text = "Nói “Trợ lý ơi” khi chưa mở app",
-                            fontSize = 14.sp,
-                            fontWeight = FontWeight.Medium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
-                    Spacer(modifier = Modifier.width(8.dp))
-                    IosStyleSwitch(
-                        checked = troLyNoiEnabled,
-                        onCheckedChange = { turnOn ->
-                            if (turnOn) {
-                                continueEnableHolder.invoke()
-                            } else {
-                                disableTroLyNoi()
-                            }
-                        },
-                        contentDescription = if (troLyNoiEnabled) {
-                            "Tắt Trợ lý nổi"
-                        } else {
-                            "Bật Trợ lý nổi"
+                        Box(
+                            modifier = Modifier
+                                .size(36.dp)
+                                .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.12f), CircleShape),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Icon(
+                                imageVector = Icons.Rounded.GraphicEq,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.size(20.dp)
+                            )
                         }
-                    )
+                        Spacer(modifier = Modifier.width(12.dp))
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = "Trợ lý nổi",
+                                fontSize = 18.sp,
+                                fontWeight = FontWeight.Bold,
+                                color = MaterialTheme.colorScheme.onSurface
+                            )
+                            Spacer(modifier = Modifier.height(4.dp))
+                            Text(
+                                text = "Nói “Trợ lý ơi” khi chưa mở app",
+                                fontSize = 14.sp,
+                                fontWeight = FontWeight.Medium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                        Spacer(modifier = Modifier.width(8.dp))
+                        IosStyleSwitch(
+                            checked = troLyNoiEnabled,
+                            onCheckedChange = { turnOn ->
+                                if (turnOn) {
+                                    continueEnableHolder.invoke()
+                                } else {
+                                    disableTroLyNoi()
+                                }
+                            },
+                            contentDescription = if (troLyNoiEnabled) {
+                                "Tắt Trợ lý nổi"
+                            } else {
+                                "Bật Trợ lý nổi"
+                            }
+                        )
+                    }
+
+                    Spacer(modifier = Modifier.height(14.dp))
+
+                    OutlinedButton(
+                        onClick = {
+                            TroLyNoiForegroundController.openOverlay(context)
+                        },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(44.dp),
+                        shape = RoundedCornerShape(12.dp),
+                        colors = ButtonDefaults.outlinedButtonColors(
+                            containerColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.07f),
+                            contentColor = MaterialTheme.colorScheme.primary
+                        ),
+                        border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary.copy(alpha = 0.25f))
+                    ) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.Center
+                        ) {
+                            Icon(
+                                imageVector = Icons.Rounded.PlayArrow,
+                                contentDescription = null,
+                                modifier = Modifier.size(18.dp)
+                            )
+                            Spacer(modifier = Modifier.width(6.dp))
+                            Text(
+                                text = "Thử nghiệm",
+                                fontSize = 14.sp,
+                                fontWeight = FontWeight.SemiBold
+                            )
+                        }
+                    }
                 }
             }
         }

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,4 +1,16 @@
 <resources>
 
     <style name="Theme.ViDroidCall" parent="android:Theme.Material.Light.NoActionBar" />
+
+    <style name="Theme.ViDroidCall.Translucent" parent="Theme.ViDroidCall">
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:colorBackgroundCacheHint">@null</item>
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowAnimationStyle">@android:style/Animation.Translucent</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowContentOverlay">@null</item>
+        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+    </style>
 </resources>

--- a/app/src/test/java/com/example/ViDroidCall_Studio/TroLyNoStateTest.kt
+++ b/app/src/test/java/com/example/ViDroidCall_Studio/TroLyNoStateTest.kt
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 ViDroidCall Studio contributors
+
+package com.example.ViDroidCall_Studio
+
+import com.example.ViDroidCall_Studio.domain.model.NativeAction
+import com.example.ViDroidCall_Studio.feature.overlay.TroLyNoState
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Kiểm thử State Machine và các quy tắc an toàn (Critical Safety Rules) cho Trợ lý nổi (TroLyNoState).
+ */
+class TroLyNoStateTest {
+
+    @Test
+    fun testInitialStateIsListening() {
+        val state: TroLyNoState = TroLyNoState.Listening
+        assertTrue(state is TroLyNoState.Listening)
+    }
+
+    @Test
+    fun testSttStateCarriesTranscript() {
+        val transcript = "Gọi cho mẹ"
+        val state: TroLyNoState = TroLyNoState.Stt(text = transcript)
+        assertTrue(state is TroLyNoState.Stt)
+        assertEquals("Gọi cho mẹ", (state as TroLyNoState.Stt).text)
+    }
+
+    @Test
+    fun testCallContactActionRequiresConfirmation() {
+        val callAction = NativeAction.CallContact(
+            contact = "Mẹ",
+            phoneNumber = "0901234567"
+        )
+        // CRITICAL SAFETY: call_contact bắt buộc phải có requiresConfirmation = true
+        assertTrue(callAction.requiresConfirmation)
+        assertEquals("call_contact", callAction.intentName)
+        assertEquals("Xác nhận thực hiện cuộc gọi?", callAction.getConfirmationTitle())
+        assertTrue(callAction.getConfirmationDescription().contains("Mẹ"))
+    }
+
+    @Test
+    fun testSendSmsActionRequiresConfirmation() {
+        val smsAction = NativeAction.SendSms(
+            contact = "Mẹ",
+            phoneNumber = "0901234567",
+            message = "Con về muộn"
+        )
+        // CRITICAL SAFETY: send_sms bắt buộc phải có requiresConfirmation = true
+        assertTrue(smsAction.requiresConfirmation)
+        assertEquals("send_sms", smsAction.intentName)
+        assertEquals("Xác nhận gửi tin nhắn?", smsAction.getConfirmationTitle())
+        assertTrue(smsAction.getConfirmationDescription().contains("Mẹ"))
+        assertTrue(smsAction.getConfirmationDescription().contains("Con về muộn"))
+    }
+
+    @Test
+    fun testSafeActionDoesNotRequireConfirmation() {
+        val openApp = NativeAction.OpenApp(appName = "YouTube")
+        assertFalse(openApp.requiresConfirmation)
+    }
+
+    @Test
+    fun testConfirmationStateHoldsPendingActionWithoutAutoExecuting() {
+        val callAction = NativeAction.CallContact(contact = "Bố", phoneNumber = "0912345678")
+        var isActionExecuted = false
+
+        // Khi NLU phân tích ra câu lệnh nhạy cảm, chuyển state sang Confirmation
+        val state: TroLyNoState = TroLyNoState.Confirmation(
+            text = "Gọi cho bố",
+            action = callAction
+        )
+
+        assertTrue(state is TroLyNoState.Confirmation)
+        // Hành động CHƯA được thực thi
+        assertFalse(isActionExecuted)
+
+        // Chỉ khi người dùng bấm Xác nhận, cờ execute mới được bật
+        fun onConfirmClick(confirmState: TroLyNoState.Confirmation) {
+            isActionExecuted = true
+        }
+
+        onConfirmClick(state as TroLyNoState.Confirmation)
+        assertTrue(isActionExecuted)
+    }
+
+    @Test
+    fun testCancelConfirmationDoesNotExecuteAction() {
+        val smsAction = NativeAction.SendSms(contact = "Anh trai", phoneNumber = "0987654321", message = "Alo")
+        var isActionExecuted = false
+
+        val state: TroLyNoState = TroLyNoState.Confirmation(
+            text = "Nhắn tin cho anh",
+            action = smsAction
+        )
+
+        // Khi bấm Hủy:
+        fun onCancelClick() {
+            // Không thực thi gì cả
+        }
+
+        onCancelClick()
+        assertFalse(isActionExecuted)
+    }
+
+    @Test
+    fun testFastPathStateWithSafeAction() {
+        val openMap = NativeAction.OpenMap(destination = "Bệnh viện Bạch Mai")
+        val state: TroLyNoState = TroLyNoState.FastPath(
+            text = "Chỉ đường tới Bệnh viện Bạch Mai",
+            action = openMap
+        )
+        assertTrue(state is TroLyNoState.FastPath)
+        assertEquals("open_map", (state as TroLyNoState.FastPath).action.intentName)
+    }
+
+    @Test
+    fun testAnalyzingState() {
+        val state: TroLyNoState = TroLyNoState.Analyzing
+        assertTrue(state is TroLyNoState.Analyzing)
+    }
+
+    @Test
+    fun testClarifyState() {
+        val state: TroLyNoState = TroLyNoState.Clarify(
+            text = "Đặt báo thức",
+            missing = listOf("Giờ báo thức")
+        )
+        assertTrue(state is TroLyNoState.Clarify)
+        val clarify = state as TroLyNoState.Clarify
+        assertEquals(1, clarify.missing.size)
+        assertEquals("Giờ báo thức", clarify.missing[0])
+    }
+}


### PR DESCRIPTION
### 📌 Liên quan đến Issue
Closes #50 - Feature: Trợ lý nổi – Overlay Bottom Sheet

---

### 📝 Tóm tắt thay đổi (Overview)
Triển khai hoàn chỉnh UI overlay cho **Trợ lý nổi** bằng Jetpack Compose.
- Overlay là một lớp UI hoàn toàn trong suốt nằm đè lên Home / ứng dụng hiện tại của Android (YouTube, TikTok, Launcher...). **Tuyệt đối không vẽ lại Home/Launcher giả**.
- Hộp thoại đáy màn hình (**TroLyNoSheet**) bám sát đáy (`bottom-pinned`), tuân thủ chuẩn thiết kế Stitch từ Project `3166014977779256200`.
- Thêm nút **"Thử nghiệm"** trong mục Cài đặt (ngay dưới switch bật/tắt Trợ lý nổi) để kiểm tra bật popup trực tiếp.

---

### 🚀 Chi tiết thay đổi (Key Changes)

#### 1. Style & Translucent Activity
- **`themes.xml`**: Thêm `Theme.ViDroidCall.Translucent` với `windowIsTranslucent = true`, nền trong suốt, hỗ trợ edge-to-edge.
- **`AndroidManifest.xml`**: Đăng ký `TroLyNoiOverlayActivity` với theme trong suốt, `launchMode="singleTop"`, `excludeFromRecents="true"`.

#### 2. State Machine & Giao diện Compose (Stitch Glassmorphism)
- **`TroLyNoState.kt`**: Quản lý 6 trạng thái:
  - `Listening`: Đang lắng nghe mic, hiển thị waveform animation.
  - `Stt`: Cập nhật transcript giọng nói theo thời gian thực.
  - `FastPath`: Nhận diện lệnh nhanh (< 5ms) không qua LLM.
  - `Analyzing`: Đang phân tích bằng mô hình AI cục bộ (loading spinner).
  - `Confirmation`: Hộp thoại xác nhận thao tác rủi ro cao.
  - `Clarify`: Yêu cầu làm rõ nội dung câu lệnh còn thiếu.
- **`TroLyNoSheet.kt`**: 
  - Card bo tròn `28.dp`, màu kính mờ frosted glassmorphic (`#F8FFFFFF`).
  - Header thương hiệu ViDroidCall (`#0866FF`) kèm status badge linh hoạt theo từng trạng thái.
  - Sound waveform 5 cột sóng âm thanh chuyển động nhịp nhàng khi nghe mic.
  - Responsive: Neo cố định ở đáy (`navigationBarsPadding`), co giãn tốt trên màn hình tablet/điện thoại lớn (`widthIn(max = 600.dp)`).

#### 3. Quy tắc an toàn bắt buộc (Critical Safety Rule)
- Các hành động rủi ro cao như `call_contact` (gọi điện) và `send_sms` (gửi tin nhắn) **luôn chuyển sang trạng thái `Confirmation`**.
- Chỉ thực hiện `executeNativeAction()` sau khi người dùng bấm nút **"Xác nhận"**. Bấm nút **"Hủy"** hoặc bấm ra ngoài màn hình sẽ hủy bỏ thao tác.

#### 4. Host Activity & Controller
- **`TroLyNoiOverlayActivity.kt`**:
  - Tự động đóng overlay khi màn hình tắt hoặc bị khóa bởi Keyguard (`isDeviceLocked`).
  - Hỗ trợ click-outside (chạm vùng trống ngoài sheet) để tắt nhanh.
  - Bắt sự kiện phím Back phần cứng (`BackHandler`) để hủy STT/TTS và giải phóng tài nguyên.
  - Xử lý `onNewIntent` để nhận lệnh tức thì khi Activity đang mở (`singleTop`).
- **`SettingsScreen.kt`**:
  - Bổ sung nút **`▶ Thử nghiệm`** bên dưới switch *"Nói “Trợ lý ơi” khi chưa mở app"* giúp tester/người dùng trải nghiệm mở popup trợ lý trực tiếp ngay trong app.

---

### 🧪 Kết quả kiểm thử (Testing & Verification)

- [x] **Unit Tests**:
  - Chạy toàn bộ test suite: `.\gradlew.bat testDebugUnitTest`
  - Đạt **100% PASS** (bao gồm test suite mới `TroLyNoStateTest.kt` kiểm tra 6 trạng thái và quy tắc rủi ro).
- [x] **Kiểm thử trên thiết bị thật (On-Device via ADB MCP)**:
  - Đã cài đặt và kiểm thử trực tiếp trên điện thoại Android vật lý.
  - ✅ Overlay hiển thị đè lên màn hình Launcher thật (thấy rõ widget Shopee và các app phía sau).
  - ✅ Hộp thoại hiển thị chuẩn xác ở đáy màn hình.
  - ✅ Bấm nút "Thử nghiệm" trong Cài đặt mở popup mượt mà.
  - ✅ Thử nghiệm lệnh gọi điện (`gọi 115`): hiện popup Xác nhận, không tự động gọi khi chưa bấm xác nhận.
  - ✅ Chạm ra ngoài khoảng trống hoặc bấm phím Back: overlay đóng ngay lập tức, không gây crash hoặc rò rỉ bộ nhớ.
